### PR TITLE
Restricted analysis

### DIFF
--- a/analysis/global_posthoc3_af_oac.do
+++ b/analysis/global_posthoc3_af_oac.do
@@ -1,0 +1,73 @@
+/***************************************************************************
+***************************************************************************
+Objective 1: Compare oral anticoagulant treated vs untreated
+in people with atrial fibrillation
+***************************************************************************
+======================================================================*/
+*set filepaths
+global projectdir `c(pwd)'
+di "$projectdir"
+global outdir "$projectdir/output" 
+di "$outdir"
+global tempdir_main_analysis "$projectdir/output/oac_tempdata" 
+di "$tempdir_main_analysis"
+global logdir "$projectdir/output/post_hoc_3_af_oac_log"
+di "$logdir"
+global tempdir "$projectdir/output/post_hoc_3_af_oac_tempdata" 
+di "$tempdir"
+global tabfigdir "$projectdir/output/post_hoc_3_af_oac_tabfig" 
+di "$tabfigdir"
+
+adopath + "$projectdir/analysis/extra_ados"
+
+* Create directories required 
+capture mkdir "$outdir/post_hoc_3_af_oac_tabfig"
+capture mkdir "$outdir/post_hoc_3_af_oac_log"
+capture mkdir "$outdir/post_hoc_3_af_oac_tempdata"
+
+* Set globals that will print in programs and direct output
+
+global population "Obj_1_AF"
+global cum_death_ymax 0.1
+global dagvarlist i.imd 					///	
+				  i.obese4cat			    ///
+				  i.smoke_nomiss		    ///
+				  i.diabcat					///
+				  i.myocardial_infarct		///
+				  i.pad						///
+				  i.hypertension			///		
+				  i.heart_failure			///		
+				  i.stroke_tia              ///
+				  i.vte                     ///
+				  i.oestrogen 				///	
+				  i.antiplatelet            ///
+				  i.flu_vaccine 			
+
+global fullvarlist i.imd 					///
+				   i.obese4cat			    ///
+				   i.smoke_nomiss		    ///
+				   i.diabcat				///
+				   i.myocardial_infarct		///
+				   i.pad					///
+				   i.hypertension			///		
+				   i.heart_failure			///		
+				   i.stroke_tia             ///
+				   i.vte                    ///
+				   i.oestrogen 				///	
+				   i.antiplatelet           ///
+				   i.flu_vaccine 			///
+				   i.ckd	 				///		
+				   i.copd                   ///
+				   i.other_respiratory      ///
+				   i.immunodef_any		 	///
+				   i.cancer     		    ///
+				   i.ae_attendance_last_year ///
+				   i.gp_consult 			
+
+/* SET FU DATES===============================================================*/ 
+* Censoring dates for each outcome
+* https://github.com/opensafely/rapid-reports/blob/master/notebooks/latest-dates.ipynb
+global onscoviddeathcensor   	= "28/09/2020"
+global apcscensor           	= "01/10/2020"
+global indexdate 			    = "01/03/2020"
+global covidtestcensor          = "30/09/2020"

--- a/analysis/global_posthoc3_af_warfarin.do
+++ b/analysis/global_posthoc3_af_warfarin.do
@@ -1,0 +1,74 @@
+/***************************************************************************
+***************************************************************************
+Objective 2: Compare warfarin vs DOACs
+in people with atrial fibrillation
+***************************************************************************
+======================================================================*/
+*set filepaths
+global projectdir `c(pwd)'
+di "$projectdir"
+global outdir "$projectdir/output" 
+di "$outdir"
+global tempdir_main_analysis "$projectdir/output/warfarin_tempdata" 
+di "$tempdir_main_analysis"
+global logdir "$projectdir/output/post_hoc_3_af_warfarin_log"
+di "$logdir"
+global tempdir "$projectdir/output/post_hoc_3_af_warfarin_tempdata" 
+di "$tempdir"
+global tabfigdir "$projectdir/output/post_hoc_3_af_warfarin_tabfig" 
+di "$tabfigdir"
+adopath + "$projectdir/analysis/extra_ados"
+
+* Create directories required 
+capture mkdir "$outdir/post_hoc_3_af_warfarin_tabfig"
+capture mkdir "$outdir/post_hoc_3_af_warfarin_log"
+capture mkdir "$outdir/post_hoc_3_af_warfarin_tempdata"
+
+* Set globals that will print in programs and direct output
+
+global population "Obj_2_AF"
+global cum_death_ymax 0.1
+global dagvarlist i.imd 					///	
+				  i.obese4cat			    ///
+				  i.smoke_nomiss		    ///
+				  i.diabcat					///
+				  i.myocardial_infarct		///
+				  i.pad						///
+				  i.hypertension			///		
+				  i.heart_failure			///		
+				  i.stroke_tia              ///
+				  i.vte                     ///
+				  i.oestrogen 				///	
+				  i.antiplatelet            ///
+				  i.flu_vaccine 			///
+				  i.care_home_residence
+
+global fullvarlist i.imd 					///
+				   i.obese4cat			    ///
+				   i.smoke_nomiss		    ///
+				   i.diabcat				///
+				   i.myocardial_infarct		///
+				   i.pad					///
+				   i.hypertension			///		
+				   i.heart_failure			///		
+				   i.stroke_tia             ///
+				   i.vte                    ///
+				   i.oestrogen 				///	
+				   i.antiplatelet           ///
+				   i.flu_vaccine 			///
+				   i.ckd	 				///		
+				   i.copd                   ///
+				   i.other_respiratory      ///
+				   i.immunodef_any		 	///
+				   i.cancer     		    ///
+				   i.ae_attendance_last_year ///
+				   i.gp_consult 			///
+				   i.care_home_residence
+				   
+/* SET FU DATES===============================================================*/ 
+* Censoring dates for each outcome
+* https://github.com/opensafely/rapid-reports/blob/master/notebooks/latest-dates.ipynb
+global onscoviddeathcensor   	= "28/09/2020"
+global apcscensor           	= "01/10/2020"
+global indexdate 			    = "01/03/2020"
+global covidtestcensor          = "30/09/2020"

--- a/analysis/posthoc3_02a_cr_create_population.do
+++ b/analysis/posthoc3_02a_cr_create_population.do
@@ -1,0 +1,52 @@
+/*==============================================================================
+DO FILE NAME:			posthoc3_02a_cr_create_population
+PROJECT:				Anticoauglant in COVID-19 
+DATE: 					26 July 2021
+AUTHOR:					A Wong	
+DESCRIPTION OF FILE:	AF population (Objective 1)
+						comparing oral anticoagulant use vs non-use
+						Post hoc analysis - restrict the study cohort to people with positive COVID tests
+DEPENDENCIES: 
+DATASETS USED:			data in memory (from analysis_dataset_`outcome')
+
+DATASETS CREATED: 		analysis_dataset.dta
+						lives in folder analysis/$tempdir 
+OTHER OUTPUT: 			logfiles, printed to folder analysis/$logdir
+						input_af_oac in output folder
+							
+==============================================================================*/
+
+local outcome `1'
+
+local global_option `2'
+
+do `c(pwd)'/analysis/global_`global_option'.do
+
+* Open a log file
+
+cap log close
+log using $logdir/posthoc3_02a_cr_create_population_`outcome', replace t
+
+/* Use the dataset we derived from the 02a program===========================*/ 
+
+use $tempdir_main_analysis/analysis_dataset_`outcome' , clear
+
+noi di "PEOPLE WITH POSITIVE COVID TESTS"
+keep if positivecovidtest == 1
+
+/* SAVE DATA==================================================================*/		
+
+save $tempdir/analysis_dataset_`outcome', replace
+
+* Save a version set on outcomes
+stset stime_`outcome', fail(`outcome') id(patient_id) enter(enter_date) origin(enter_date)	
+save $tempdir/analysis_dataset_STSET_`outcome', replace
+
+* Close log file 
+log close
+
+
+
+
+
+

--- a/analysis/posthoc3_02b_cr_create_population.do
+++ b/analysis/posthoc3_02b_cr_create_population.do
@@ -1,0 +1,51 @@
+/*==============================================================================
+DO FILE NAME:			posthoc3_02b_cr_create_population
+PROJECT:				Anticoauglant in COVID-19 
+DATE: 					26 July 2021
+AUTHOR:					A Wong 
+DESCRIPTION OF FILE:	Based on program 02b, AF population (Objective 2)
+						comparing warfarin vs DOACs
+						post-hoc analysis - restrict the study cohort to people with positive covid tests
+DEPENDENCIES: 
+DATASETS USED:			data in memory (from analysis_dataset_`outcome')
+
+DATASETS CREATED: 		analysis_dataset.dta
+						lives in folder analysis/$tempdir 
+OTHER OUTPUT: 			logfiles, printed to folder analysis/$logdir
+							
+==============================================================================*/
+
+local outcome `1'
+
+local global_option `2'
+
+do `c(pwd)'/analysis/global_`global_option'.do
+
+* Open a log file
+
+cap log close
+log using $logdir/posthoc3_02b_cr_create_population_`outcome', replace t
+
+/* Use the dataset we derived from the 02b program=============================*/ 
+
+use $tempdir_main_analysis/analysis_dataset_`outcome', clear
+
+noi di "PEOPLE WITH POSITIVE COVID TESTS"
+keep if positivecovidtest == 1
+
+/* SAVE DATA==================================================================*/	
+
+save $tempdir/analysis_dataset_`outcome', replace
+
+* Save a version set on outcomes
+stset stime_`outcome', fail(`outcome') id(patient_id) enter(enter_date) origin(enter_date)	
+save $tempdir/analysis_dataset_STSET_`outcome', replace
+
+* Close log file 
+log close
+
+
+
+
+
+

--- a/project.yaml
+++ b/project.yaml
@@ -3022,3 +3022,57 @@ actions:
         data4: "output/warfarin_tempdata/12b_mi_ons_multivar2_withoutethn.ster"
         data5: "output/warfarin_tempdata/12b_mi_ons_multivar3_ethn.ster"
         data6: "output/warfarin_tempdata/12b_mi_ons_multivar3_withoutethn.ster"
+
+  # Post-hoc analysis 3 - restrict the population to people with positive COVID tests
+  # Objective 1: compare AF treated people with AF non-treated people
+
+  # Primary Outcomes: ONS COVID-19 death
+  posthoc3_02a_cr_create_population_af_oac_onscoviddeath:
+    run: stata-mp:latest analysis/posthoc3_02a_cr_create_population.do onscoviddeath posthoc3_af_oac
+    needs: [02aii_cr_create_population_af_oac_onscoviddeath]
+    outputs:
+      moderately_sensitive:
+        log: output/post_hoc_3_af_oac_log/posthoc3_02a_cr_create_population_onscoviddeath.log
+      highly_sensitive:
+        data1: "output/post_hoc_3_af_oac_tempdata/analysis_dataset_onscoviddeath.dta"
+        data2: "output/post_hoc_3_af_oac_tempdata/analysis_dataset_STSET_onscoviddeath.dta"
+
+  posthoc3_05a_an_models_af_oac_onscoviddeath:
+    run: stata-mp:latest analysis/05a_an_models.do onscoviddeath posthoc3_af_oac
+    needs: [posthoc3_02a_cr_create_population_af_oac_onscoviddeath, 05a_an_models_af_oac_onscoviddeath]
+    outputs:
+      moderately_sensitive:
+        log: output/post_hoc_3_af_oac_log/05a_an_models_onscoviddeath.log
+        table: "output/post_hoc_3_af_oac_tabfig/table2_onscoviddeath.txt"
+      highly_sensitive:
+        data1: "output/post_hoc_3_af_oac_tempdata/onscoviddeath_univar.ster"
+        data2: "output/post_hoc_3_af_oac_tempdata/onscoviddeath_multivar1.ster"
+        data3: "output/post_hoc_3_af_oac_tempdata/onscoviddeath_multivar2.ster"
+        data4: "output/post_hoc_3_af_oac_tempdata/onscoviddeath_multivar3.ster"
+
+  # Post-hoc analysis: restrict the study cohort to people with positive COVID test
+  # Objective 2: Compare warfarin users and DOAC users
+
+  # Primary Outcomes: ONS COVID-19 death
+  posthoc3_02b_cr_create_population_af_warfarin_onscoviddeath:
+    run: stata-mp:latest analysis/posthoc3_02b_cr_create_population.do onscoviddeath posthoc3_af_warfarin
+    needs: [02b_cr_create_population_af_warfarin_onscoviddeath]
+    outputs:
+      moderately_sensitive:
+        log: output/post_hoc_3_af_warfarin_log/posthoc3_02b_cr_create_population_onscoviddeath.log
+      highly_sensitive:
+        data1: "output/post_hoc_3_af_warfarin_tempdata/analysis_dataset_onscoviddeath.dta"
+        data2: "output/post_hoc_3_af_warfarin_tempdata/analysis_dataset_STSET_onscoviddeath.dta"
+
+  posthoc3_05b_an_models_af_warfarin_onscoviddeath:
+    run: stata-mp:latest analysis/05b_an_models.do onscoviddeath posthoc3_af_warfarin
+    needs: [posthoc3_02b_cr_create_population_af_warfarin_onscoviddeath, 05b_an_models_af_warfarin_onscoviddeath]
+    outputs:
+      moderately_sensitive:
+        log: output/post_hoc_3_af_warfarin_log/05b_an_models_onscoviddeath.log
+        table: "output/post_hoc_3_af_warfarin_tabfig/table2_onscoviddeath.txt"
+      highly_sensitive:
+        data1: "output/post_hoc_3_af_warfarin_tempdata/onscoviddeath_univar.ster"
+        data2: "output/post_hoc_3_af_warfarin_tempdata/onscoviddeath_multivar1.ster"
+        data3: "output/post_hoc_3_af_warfarin_tempdata/onscoviddeath_multivar2.ster"
+        data4: "output/post_hoc_3_af_warfarin_tempdata/onscoviddeath_multivar3.ster"


### PR DESCRIPTION
Run a new post-hoc analysis to restrict study cohort to people with positive COVID tests:
1. Add actions to run the do-files in project.yaml
2. Add global do-files for folder and file location
3. Add do-files to create the cohort to run this analysis (posthoc3_02a_cr_create_population & posthoc3_02b_cr_create_population)
